### PR TITLE
認証・認可失敗のログを出力, S3バケット未指定の場合に認証スキップ

### DIFF
--- a/src/cloudfront-authorizer.ts
+++ b/src/cloudfront-authorizer.ts
@@ -20,9 +20,10 @@ export class CloudFrontAuthorizer {
 
   async authorize(request: CloudFrontRequest): Promise<CloudFrontRequest | CloudFrontResultResponse> {
     if (this.#allowedCidrBlocks.contains(request.clientIp)) {
-      console.warn(`The client ip '${request.clientIp}' is not allowed.`)
       return request
     }
+
+    console.warn(`The client ip '${request.clientIp}' is not allowed.`)
 
     if (await this.authProvider.authenticate(request)) {
       return request

--- a/src/cloudfront-authorizer.ts
+++ b/src/cloudfront-authorizer.ts
@@ -20,6 +20,7 @@ export class CloudFrontAuthorizer {
 
   async authorize(request: CloudFrontRequest): Promise<CloudFrontRequest | CloudFrontResultResponse> {
     if (this.#allowedCidrBlocks.contains(request.clientIp)) {
+      console.warn(`The client ip '${request.clientIp}' is not allowed.`)
       return request
     }
 


### PR DESCRIPTION
なぜ認可に失敗したかのログを出力するようにしました。
また、S3 Bucket が空の場合に S3 ファイル認証をスキップするようにしました。